### PR TITLE
fix(docker): docker image artifact path FGR3-5289

### DIFF
--- a/.github/actions/docker-build-image/action.yml
+++ b/.github/actions/docker-build-image/action.yml
@@ -40,7 +40,7 @@ runs:
 
     - id: docker_file
       shell: bash
-      run: echo "file_name=$(echo ${{ inputs.repository-name }} | tr / -)-${{ steps.sha_short.outputs.sha_short }}.tar" >> $GITHUB_OUTPUT
+      run: echo "file_name=${{ inputs.service-name }}-${{ steps.sha_short.outputs.sha_short }}.tar" >> $GITHUB_OUTPUT
 
     - uses: docker/build-push-action@v5
       with:

--- a/.github/actions/docker-load-image/action.yml
+++ b/.github/actions/docker-load-image/action.yml
@@ -13,7 +13,7 @@ runs:
 
     - id: docker_file
       shell: bash
-      run: echo "file_name=$(echo ${{ inputs.service-name }} | tr / -)-${{ steps.sha_short.outputs.sha_short }}.tar" >> $GITHUB_OUTPUT
+      run: echo "file_name=${{ inputs.service-name }}-${{ steps.sha_short.outputs.sha_short }}.tar" >> $GITHUB_OUTPUT
 
     - uses: actions/download-artifact@v4.1.0
       with:

--- a/.github/actions/terraform-init/action.yml
+++ b/.github/actions/terraform-init/action.yml
@@ -56,6 +56,7 @@ runs:
 
         $SSH_CMD -o ProxyCommand="aws ssm start-session --target $INSTANCE_ID --document-name AWS-StartSSHSession --parameters portNumber=22" ec2-user@bastion &
         sleep 1
+      shell: bash
       env:
         aws-region: ${{ inputs.aws-region }}
         db-tunnel-mapping: ${{ inputs.db-tunnel-mapping }}


### PR DESCRIPTION
Měl jsem blbě cestu na kterou se ukládá docker image do artefaktů. Má to být `<service-name>-<hash>.tar` (`build-image` akce ho tam uploadne a `load-image` zase downloadne - je to kvůli tomu aby se mohl reusovat stejný docker image mezi joby a nemuseli jsme ho pushovat do ECR kvůli každýmu spuštění pipeliny.)