### PR TITLE
fix(docker): do not push image to ECR if already exists

### DIFF
--- a/.github/actions/docker-push-image/action.yml
+++ b/.github/actions/docker-push-image/action.yml
@@ -36,5 +36,12 @@ runs:
         
         MANIFEST=$(aws ecr batch-get-image --region "${{ inputs.aws-region }}" --repository-name "${{ inputs.repository-name }}" --image-ids imageTag="${{ steps.sha_short.outputs.sha_short }}" --query 'images[].imageManifest' --output text)
         
-        aws ecr put-image --region "${{ inputs.aws-region }}" --repository-name "${{ inputs.repository-name }}" --image-tag "latest" --image-manifest "$MANIFEST"
+        # Check if the image with the 'latest' tag already exists
+        IMAGE_EXISTS=$(aws ecr describe-images --region "${{ inputs.aws-region }}" --repository-name "${{ inputs.repository-name }}" --image-ids imageTag="latest" imageTag="${{ steps.sha_short.outputs.sha_short }}" --query 'imageDetails' --output text)
+
+        if [ -z "$IMAGE_EXISTS" ]; then
+          aws ecr put-image --region "${{ inputs.aws-region }}" --repository-name "${{ inputs.repository-name }}" --image-tag "latest" --image-manifest "$MANIFEST"
+        else
+          echo "Image with tags 'latest' and '${{ steps.sha_short.outputs.sha_short }}' already exists. Skipping put-image."
+        fi
       shell: bash


### PR DESCRIPTION
Když se nemění kód servisy, tak docker build vyprodukuje ten samý image co předchozí pipelina a tady ten put potom vyfailuje. V Circlu jsme ten if měli, tak nevím proč jsem to nezkopíroval. 🤦‍♂️ https://github.com/FigurePOS/circle-ci-node-ecs-orb/blob/e3c0e21782235d6cbcfb0c13e1c0e7094bd632d2/src/scripts/push-image.sh#L10-L15