### PR TITLE
fix: escaping ota messge FGR3-6322

### DIFF
--- a/.github/workflows/update-mobile-ota.yml
+++ b/.github/workflows/update-mobile-ota.yml
@@ -105,8 +105,8 @@ jobs:
         env:
           GIT_MESSAGE: ${{ steps.get-git-message.outputs.message }}
         run: |
-          git_message=${GIT_MESSAGE//\"/\\\"}
-          message=$(printf "v%s: %s" "${{ inputs.version }}" "$git_message")
+          message_git=${GIT_MESSAGE//\"/\\\"}
+          message=$(printf "v%s: %s" "${{ inputs.version }}" "$message_git")
           echo "Running deployment for:"
           echo "  environment: '${{ inputs.environment }}'"
           echo "  platform: '${{ inputs.platform }}'"


### PR DESCRIPTION
Myslím, že ta ENV je potřeba, abych to dostal do nějaké bash proměné. Nenapadá mě jak jinak to uložit do proměné, pokud to může obsahovat `'` i `"`.