### PR TITLE
fix: ci lambda test

### DIFF
--- a/.github/actions/ci-node-test-lambda/action.yml
+++ b/.github/actions/ci-node-test-lambda/action.yml
@@ -27,7 +27,6 @@ runs:
       uses: FigurePOS/github-actions/.github/actions/node-setup@v3
 
     - name: Process Linters and Tests for Lambda Functions
-      if: steps.check-lambda.outputs.lambda-exists == 'true'
       uses: FigurePOS/github-actions/.github/actions/node-test-lambda@v3
       with:
         directory: ${{ inputs.directory }}


### PR DESCRIPTION
Tohle jsem zapomněl smazat. Používá se to jen v běžných testech, kde se spustí testy pro `/src` a potom se hledá jestli existuje `/lambda`: https://github.com/FigurePOS/github-actions/blob/28604c5d07ecde61cafa0067270655a42bb75243/.github/actions/ci-node-test-unit/action.yml#L66-L83