### PR TITLE
fix: notify buddy

### DIFF
--- a/.github/workflows/service-ci.yml
+++ b/.github/workflows/service-ci.yml
@@ -174,3 +174,14 @@ jobs:
           github-token-terraform: ${{ secrets.GH_TOKEN_TERRAFORM }}
           service-name: ${{ inputs.service-name }}
           ssm-parameters: "DATADOG_API_KEY=/terraform/datadog/api_key,DATADOG_APP_KEY=/terraform/datadog/app_key"
+
+  notify-buddy:
+    if: github.ref == 'refs/heads/master'
+    needs:
+      - terraform-deploy-dev
+    runs-on: blacksmith-2vcpu-ubuntu-2204
+    steps:
+      - uses: FigurePOS/github-actions/.github/actions/ci-notify-buddy@v3
+        with:
+          buddy-trigger-url: ${{ secrets.BUDDY_TRIGGER_URL }}
+          service-name: ${{ inputs.service-name }}


### PR DESCRIPTION
Jsem se tady v tom PR https://github.com/FigurePOS/github-actions/pull/51 nějak moc rozohnil: 😅 
![CleanShot 2025-05-19 at 12 52 37](https://github.com/user-attachments/assets/82a905a3-62c4-433d-b17e-5953bc0404ab)
(to je notifikace servisy o dokončení dev deploymentu)