### PR TITLE
feat: set up npm token on terraform deploy FGR3-6515

### DIFF
--- a/.github/actions/terraform-apply/action.yml
+++ b/.github/actions/terraform-apply/action.yml
@@ -20,6 +20,11 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Set GitHub Packages Token for Lambda Deployment
+      shell: bash
+      run: |
+        npm config set //npm.pkg.github.com/:_authToken ${{ github.token }}
+    
     - id: sha_short
       run: echo "sha_short=$(git rev-parse --short ${{ inputs.sha || github.sha }})" >> $GITHUB_OUTPUT
       shell: bash


### PR DESCRIPTION
Lambda deploy pouští npm install, tak je to potřeba i tady. 🙂 