### PR TITLE
fix: setup Node.js in terrafrom deploy action

### DIFF
--- a/.github/actions/ci-terraform-apply/action.yml
+++ b/.github/actions/ci-terraform-apply/action.yml
@@ -59,7 +59,7 @@ runs:
       uses: actions/checkout@v4
 
     - name: Set Up Node.js
-      uses: FigurePOS/github-actions/.github/actions/node-setup@v3
+      uses: FigurePOS/github-actions/.github/actions/node-setup@v4
 
     - name: Download Artifact
       if: inputs.artifact-path != ''

--- a/.github/actions/ci-terraform-apply/action.yml
+++ b/.github/actions/ci-terraform-apply/action.yml
@@ -58,6 +58,9 @@ runs:
     - name: Checkout
       uses: actions/checkout@v4
 
+    - name: Set Up Node.js
+      uses: FigurePOS/github-actions/.github/actions/node-setup@v3
+
     - name: Download Artifact
       if: inputs.artifact-path != ''
       uses: actions/download-artifact@v4


### PR DESCRIPTION
Deploy lambda funkcí instaluje závislosti a builduje node, proto je to potřeba nastavit.