### PR TITLE
fix: use dynamo locks again

### DIFF
--- a/.github/actions/terraform-init/action.yml
+++ b/.github/actions/terraform-init/action.yml
@@ -50,9 +50,9 @@ runs:
         fi
         tofu init -reconfigure \
           -backend-config="bucket=fgr-terraform-state" \
+          -backend-config="dynamodb_table=fgr-terraform-state-locks" \
           -backend-config="key=$backend_key" \
           -backend-config="region=${{ inputs.aws-region }}" \
-          -backend-config=use_lockfile=true \
           -lock-timeout=60s
       shell: bash
 


### PR DESCRIPTION
To S3 native zamykání (novinka v OpenTofu 1.10) asi nebude ještě odladěný, tak raději ještě revertuju na Dynamo. 🙄 

<img width="1011" height="833" alt="CleanShot 2025-07-14 at 09 42 40" src="https://github.com/user-attachments/assets/dcf31476-86fa-45c3-99aa-a67d2454c568" />
