### PR TITLE
fix: remove duplicate notification about deploy fail

### DIFF
--- a/.github/workflows/service-cd.yml
+++ b/.github/workflows/service-cd.yml
@@ -97,11 +97,3 @@ jobs:
                 throw error;
               }
             }
-
-      - name: Send Slack Notification About Failure
-        if: failure()
-        uses: FigurePOS/github-actions/.github/actions/buddy-notify-fail-service@v4
-        with:
-          job-name: terraform-deploy-prod
-          service-name: ${{ inputs.service-name }}
-          trigger-url: ${{ secrets.BUDDY_TRIGGER_URL }}


### PR DESCRIPTION
Ten check už je v `ci-terraform-apply` akci, tak se notifikace posílá zdvojeně:
<img width="664" height="352" alt="image" src="https://github.com/user-attachments/assets/ed539135-ccaf-453c-99ad-3f3e38a55b3f" />
