### PR TITLE
fix: improve grafana token id uniqness #2

### DIFF
--- a/.github/actions/auth-terraform-providers/action.yml
+++ b/.github/actions/auth-terraform-providers/action.yml
@@ -55,7 +55,7 @@ runs:
       env:
         AWS_REGION: ${{ inputs.aws-region }}
       run: |
-        TOKEN_UNIQUE_ID="${GITHUB_RUN_ID}-$(date +%s)"
+        TOKEN_UNIQUE_ID="${GITHUB_JOB}-$(date +%s%N | cut -c1-13)-${RANDOM}-$$"
 
         # Assume the TerraformDeployer role for Grafana operations
         echo "Assuming TerraformDeployer role..."


### PR DESCRIPTION
Tohle nepomohlo https://github.com/FigurePOS/github-actions/pull/68 protože oba joby mají stejný GITHUB_RUN_ID (běží v tom stejným workflow) 🤦‍♂️