### PR TITLE
feat: increase default node version

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -4,7 +4,7 @@ description: "Set up Node.js"
 inputs:
   version:
     description: "Node.js version to use"
-    default: "20.x"
+    default: "22.x"
 
 runs:
   using: composite


### PR DESCRIPTION
This is a change to the `v1-maintenance` branch. With updating Expo we need to use a newer node. This should affect only our repos as the BE is using npm already and a newer version than `v1`.